### PR TITLE
Improved Error types to work in browsers without v8 engine

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -7,7 +7,11 @@ function RequestError(cause) {
     this.message = String(cause);
     this.cause = cause;
 
-    Error.captureStackTrace(this);
+    if(Error.captureStackTrace){
+      Error.captureStackTrace(this);
+    } else {
+      Error.call(this);
+    }
 
 }
 RequestError.prototype = Object.create(Error.prototype);
@@ -20,7 +24,11 @@ function StatusCodeError(statusCode, message) {
     this.statusCode = statusCode;
     this.message = statusCode + ' - ' + message;
 
-    Error.captureStackTrace(this);
+    if(Error.captureStackTrace){
+      Error.captureStackTrace(this);
+    } else {
+      Error.call(this);
+    }
 
 }
 StatusCodeError.prototype = Object.create(Error.prototype);


### PR DESCRIPTION
Error.captureStackTrace is only supported in browsers with v8 engine.
With this pull request I can use request-promise in all browsers.