### PR TITLE
Simplified unnecessary loop

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -140,15 +140,9 @@ function expose(methodToExpose, exposeAs) {
 
 }
 
-_.forEach([
-        ['then'],
-        ['catch'],
-        ['finally']
-    ],
-    function (args) {
-        expose.apply(undefined, args);
-    }
-);
+expose('then');
+expose('catch');
+expose('finally');
 
 request.Request.prototype.promise = function RP$promise() {
     markPromiseInUse(this);


### PR DESCRIPTION
There is no need to use a confusing loop calling apply with arguments. Just call the function directly each time. This version is shorter and simpler no matter how many times you need to call expose.